### PR TITLE
Remove unnecessary whitespace from tag contents, closes #6

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const camelCase = require('camel-case')
 const hyperx = require('hyperx')
 const issvg = require('@f/is-svg')
 const svgNamespace = require('@f/svg-namespace')
+const normalizeWhitespace = require('normalize-html-whitespace')
 
 /**
  * Try to return a nice variable name for an element based on its HTML id,
@@ -267,6 +268,13 @@ module.exports = (babel) => {
           .reduce((flat, arr) => flat.concat(arr), [])
           // Remove empty strings since they don't affect output
           .filter(isNotEmptyString)
+          // Remove unnecessary whitespace from other strings
+          .map((child) => {
+            if (t.isStringLiteral(child)) {
+              child.value = normalizeWhitespace(child.value)
+            }
+            return child
+          })
 
         if (realChildren.length === 1 && t.isStringLiteral(realChildren[0])) {
           // Plain strings can be added as textContent straight away.

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@f/svg-namespace": "^1.0.1",
     "camel-case": "^3.0.0",
     "hyperx": "^2.0.5",
+    "normalize-html-whitespace": "^0.2.0",
     "on-load": "^3.2.0",
     "yo-yoify": "^3.5.0"
   },

--- a/test/fixtures/arrowFunctions.expected.js
+++ b/test/fixtures/arrowFunctions.expected.js
@@ -3,9 +3,9 @@ var _appendChild = require('yo-yoify/lib/appendChild'); // https://github.com/go
 const component = () => {
   var _h, _div;
 
-  _div = document.createElement('div'), _appendChild(_div, ['\n    ', (_h = document.createElement('h1'), _h.textContent = ' hello world ', _h), '\n    ', list.map(x => {
+  _div = document.createElement('div'), _appendChild(_div, [' ', (_h = document.createElement('h1'), _h.textContent = ' hello world ', _h), ' ', list.map(x => {
     var _span;
 
     _span = document.createElement('span'), _span.setAttribute('style', 'background-color: red; margin: 10px;'), _appendChild(_span, [' ', x, ' ']), _span;
-  }), '\n  ']), _div;
+  }), ' ']), _div;
 };

--- a/test/fixtures/nesting.expected.js
+++ b/test/fixtures/nesting.expected.js
@@ -2,4 +2,4 @@ var _b,
     _a,
     _appendChild = require('yo-yoify/lib/appendChild');
 
-_a = document.createElement('div'), _a.setAttribute('class', 'a'), _appendChild(_a, ['\n    ', (_b = document.createElement('div'), _b.setAttribute('class', 'b'), _b.textContent = '\n  ', _b), '\n']), _a;
+_a = document.createElement('div'), _a.setAttribute('class', 'a'), _appendChild(_a, [' ', (_b = document.createElement('div'), _b.setAttribute('class', 'b'), _b.textContent = ' ', _b), '\n']), _a;

--- a/test/fixtures/orderOfOperations.expected.js
+++ b/test/fixtures/orderOfOperations.expected.js
@@ -4,4 +4,4 @@ var _p,
 
 let i = 0;
 
-const counter = (_div = document.createElement('div'), _appendChild(_div, ['\n    ', i++, '\n    ', (_p = document.createElement('p'), _appendChild(_p, [i++]), _p), '\n    ', i++, '\n  ']), _div);
+const counter = (_div = document.createElement('div'), _appendChild(_div, [' ', i++, ' ', (_p = document.createElement('p'), _appendChild(_p, [i++]), _p), ' ', i++, ' ']), _div);

--- a/test/fixtures/simple.expected.js
+++ b/test/fixtures/simple.expected.js
@@ -1,3 +1,3 @@
 var _div;
 
-_div = document.createElement('div'), _div.textContent = '\n    Hello world\n  ', _div;
+_div = document.createElement('div'), _div.textContent = ' Hello world ', _div;

--- a/test/fixtures/svg.expected.js
+++ b/test/fixtures/svg.expected.js
@@ -5,6 +5,6 @@ var _path,
     _svg2,
     _div;
 
-const svg = (_svg = document.createElementNS(_svgNamespace, 'svg'), _svg.setAttribute('viewBox', '0 14 32 18'), _appendChild(_svg, ['\n    ', (_path = document.createElementNS(_svgNamespace, 'path'), _path.setAttribute('d', 'M2 14 V18 H6 V14z'), _path), '\n  ']), _svg);
+const svg = (_svg = document.createElementNS(_svgNamespace, 'svg'), _svg.setAttribute('viewBox', '0 14 32 18'), _appendChild(_svg, [' ', (_path = document.createElementNS(_svgNamespace, 'path'), _path.setAttribute('d', 'M2 14 V18 H6 V14z'), _path), ' ']), _svg);
 
-const htmlAndSvg = (_div = document.createElement('div'), _appendChild(_div, ['\n    ', (_svg2 = document.createElementNS(_svgNamespace, 'svg'), _svg2.textContent = '\n  ', _svg2), '\n']), _div);
+const htmlAndSvg = (_div = document.createElement('div'), _appendChild(_div, [' ', (_svg2 = document.createElementNS(_svgNamespace, 'svg'), _svg2.textContent = ' ', _svg2), '\n']), _div);


### PR DESCRIPTION
It's not quite perfect, but better:

```js
bel`
  <div>
    Contents
  </div>
`
```

currently gives

```js
_div = document.createElement('div'), _div.textContent = '\n    Contents\n  '
```

but with this patch gives

```js
_div = document.createElement('div'), _div.textContent = ' Contents '
```