### PR TITLE
Fix dynamic boolean attributes, closes #15

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@f/svg-namespace": "^1.0.1",
     "camel-case": "^3.0.0",
     "hyperx": "^2.0.5",
+    "is-boolean-attribute": "0.0.1",
     "normalize-html-whitespace": "^0.2.0",
     "on-load": "^3.2.0",
     "yo-yoify": "^3.5.0"

--- a/test/fixtures/booleanAttr.expected.js
+++ b/test/fixtures/booleanAttr.expected.js
@@ -1,0 +1,5 @@
+var _input, _input2, _button;
+
+_input = document.createElement('input'), _input.setAttribute('autofocus', 'autofocus'), _input;
+_input2 = document.createElement('input'), true && _input2.setAttribute('checked', 'checked'), _input2;
+_button = document.createElement('button'), someVariable && _button.setAttribute('disabled', 'disabled'), _button;

--- a/test/fixtures/booleanAttr.js
+++ b/test/fixtures/booleanAttr.js
@@ -1,0 +1,6 @@
+const bel = require('bel')
+
+bel`<input autofocus />`
+bel`<input checked="${true}" />`
+bel`<button disabled=${someVariable} />`
+

--- a/test/test.js
+++ b/test/test.js
@@ -27,6 +27,9 @@ function testFixture (name) {
 
         return writeActual(path.join(__dirname, 'fixtures', `${name}.actual.js`), results[0].code)
       })
+      .catch((err) => {
+        t.fail(err.message)
+      })
       .then(() => t.end())
   })
 }
@@ -37,6 +40,7 @@ testFixture('variableNames')
 testFixture('nesting')
 testFixture('elementsChildren')
 testFixture('combinedAttr')
+testFixture('booleanAttr')
 testFixture('events')
 testFixture('onload')
 testFixture('orderOfOperations')


### PR DESCRIPTION
Now if the attribute is something like `checked=${someVar}`, it'll compile to `someVar && el.setAttribute('checked', 'checked')`